### PR TITLE
improve Union deserialization when "__type" field specifier is not present

### DIFF
--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -314,16 +314,16 @@ def _decode_generic(type_, value, infer_missing):
                 # already decoded
                 res = value
             else:
-                # FIXME if all types in the union are dataclasses this
-                #  will just pick the first option -
-                #  maybe find the best fitting class in that case instead?
                 res = value
                 changed = False
                 for type_option in type_options:
                     if is_dataclass(type_option):
-                        res = _decode_dataclass(type_option, value, infer_missing)
-                        changed = True
-                        break
+                        try:
+                            res = _decode_dataclass(type_option, value, infer_missing)
+                            changed = True
+                            break
+                        except (KeyError, ValueError):
+                            continue
                 if not changed:
                     warnings.warn(
                         f"Failed encoding {value} Union dataclasses."

--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -321,7 +321,7 @@ def _decode_generic(type_, value, infer_missing):
                 changed = False
                 for type_option in type_options:
                     if is_dataclass(type_option):
-                        res = _decode_dataclass(type_options[0], value, infer_missing)
+                        res = _decode_dataclass(type_option, value, infer_missing)
                         changed = True
                         break
                 if not changed:

--- a/dataclasses_json/core.py
+++ b/dataclasses_json/core.py
@@ -314,19 +314,21 @@ def _decode_generic(type_, value, infer_missing):
                 # already decoded
                 res = value
             else:
-                # FIXME if both types in the union are dataclasses this
+                # FIXME if all types in the union are dataclasses this
                 #  will just pick the first option -
-                #  maybe find the better fitting class in that case instead?
-                if is_dataclass(type_options[0]):
-                    res = _decode_dataclass(type_options[0], value, infer_missing)
-                elif is_dataclass(type_options[1]):
-                    res = _decode_dataclass(type_options[1], value, infer_missing)
-                else:
+                #  maybe find the best fitting class in that case instead?
+                res = value
+                changed = False
+                for type_option in type_options:
+                    if is_dataclass(type_option):
+                        res = _decode_dataclass(type_options[0], value, infer_missing)
+                        changed = True
+                        break
+                if not changed:
                     warnings.warn(
                         f"Failed encoding {value} Union dataclasses."
                         f"Expected Union to include a dataclass and it didn't."
                     )
-                    res = value
     return res
 
 

--- a/tests/test_collection_of_unions.py
+++ b/tests/test_collection_of_unions.py
@@ -38,8 +38,8 @@ class Player:
 @dataclass_json
 @dataclass(frozen=True)
 class Team:
-    roster: list[int | Player]
-    roster_backup: dict[int, int | Player]
+    roster: list[Union[int, Player]]
+    roster_backup: dict[int, Union[int, Player]]
 
 
 class TestCollectionOfUnions:

--- a/tests/test_collection_of_unions.py
+++ b/tests/test_collection_of_unions.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from typing import Dict, Union, List
+import json
 
 from dataclasses_json import dataclass_json
 
@@ -40,7 +41,7 @@ class TestCollectionOfUnions:
                 }
             }
         }
-        json_str = NotWorkingDictUnion.to_json(data)
+        json_str = NotWorkingDictUnion.schema().dump(data)
         obj = NotWorkingDictUnion.from_json(json_str)
 
         # type is <class 'dict'>, as opposed to TestChild/TestOtherChild
@@ -57,7 +58,7 @@ class TestCollectionOfUnions:
                 }
             ]
         }
-        json_str = NotWorkingListUnion.to_json(data)
+        json_str = NotWorkingListUnion.schema().dump(data)
         obj = NotWorkingListUnion.from_json(json_str)
 
         # type is <class 'dict'>, as opposed to TestChild/TestOtherChild

--- a/tests/test_collection_of_unions.py
+++ b/tests/test_collection_of_unions.py
@@ -39,7 +39,7 @@ class Player:
 @dataclass(frozen=True)
 class Team:
     roster: List[Union[int, Player]]
-    roster_backup: dict[int, Union[int, Player]]
+    roster_backup: Dict[int, Union[int, Player]]
 
 
 class TestCollectionOfUnions:

--- a/tests/test_collection_of_unions.py
+++ b/tests/test_collection_of_unions.py
@@ -89,7 +89,7 @@ class TestCollectionOfUnions:
             }
         }
         json_str = json.dumps(data)
-        obj: Team = ListUnion.from_json(json_str)
+        obj: Team = Team.from_json(json_str)
 
         assert type(obj.roster[0]) is int and type(obj.roster_backup[1]) is int
 
@@ -119,7 +119,7 @@ class TestCollectionOfUnions:
             }
         }
         json_str = json.dumps(data)
-        obj: Team = ListUnion.from_json(json_str)
+        obj: Team = Team.from_json(json_str)
 
         assert type(obj.roster[0]) is Player and type(obj.roster_backup[1]) is Player
 
@@ -143,7 +143,7 @@ class TestCollectionOfUnions:
             }
         }
         json_str = json.dumps(data)
-        obj: Team = ListUnion.from_json(json_str)
+        obj: Team = Team.from_json(json_str)
 
         assert type(obj.roster[0]) is Player and type(obj.roster_backup[1]) is int
 
@@ -167,6 +167,6 @@ class TestCollectionOfUnions:
             }
         }
         json_str = json.dumps(data)
-        obj: Team = ListUnion.from_json(json_str)
+        obj: Team = Team.from_json(json_str)
 
         assert type(obj.roster[0]) is int and type(obj.roster_backup[1]) is Player

--- a/tests/test_collection_of_unions.py
+++ b/tests/test_collection_of_unions.py
@@ -19,45 +19,154 @@ class TestOtherChild:
 
 @dataclass_json
 @dataclass(frozen=True)
-class NotWorkingDictUnion:
+class DictUnion:
     d: Dict[str, Union[TestChild, TestOtherChild]]
 
 
 @dataclass_json
 @dataclass(frozen=True)
-class NotWorkingListUnion:
+class ListUnion:
     l: List[Union[TestChild, TestOtherChild]]
+
+
+@dataclass_json
+@dataclass(frozen=True)
+class Player:
+    name: str
+
+
+@dataclass_json
+@dataclass(frozen=True)
+class Team:
+    roster: list[int | Player]
+    roster_backup: dict[int, int | Player]
 
 
 class TestCollectionOfUnions:
     def test_dict(self):
         data = {
-            "d": {
-                "child" : {
-                    "some_field" : 1
+            'd': {
+                'child' : {
+                    'some_field' : 1
                 },
-                "other_child" : {
-                    "other_field" : 2
+                'other_child' : {
+                    'other_field' : 2
                 }
             }
         }
         json_str = json.dumps(data)
-        obj = NotWorkingDictUnion.from_json(json_str)
+        obj = DictUnion.from_json(json_str)
 
         assert type(obj.d['child']) in (TestChild, TestOtherChild)
 
     def test_list(self):
         data = {
-            "l": [
+            'l': [
                 {
-                    "some_field" : 1
+                    'some_field' : 1
                 },
                 {
-                    "other_field" : 1
+                    'other_field' : 1
                 }
             ]
         }
         json_str = json.dumps(data)
-        obj = NotWorkingListUnion.from_json(json_str)
+        obj = ListUnion.from_json(json_str)
 
         assert type(obj.l[0]) in (TestChild, TestOtherChild)
+
+    def test_int(self):
+        data = {
+            'roster': [
+                1,
+                2,
+                3
+            ],
+            'roster_backup': {
+                1: 5,
+                2: 3,
+                3: 2
+            }
+        }
+        json_str = json.dumps(data)
+        obj: Team = ListUnion.from_json(json_str)
+
+        assert type(obj.roster[0]) is int and type(obj.roster_backup[1]) is int
+
+    def test_dataclass(self):
+        data = {
+            'roster': [
+                {
+                    'player1'
+                },
+                {
+                    'player2'
+                },
+                {
+                    'player3'
+                }
+            ],
+            'roster_backup': {
+                1: {
+                    'player1'
+                },
+                2: {
+                    'player2'
+                },
+                3: {
+                    'player3'
+                }
+            }
+        }
+        json_str = json.dumps(data)
+        obj: Team = ListUnion.from_json(json_str)
+
+        assert type(obj.roster[0]) is Player and type(obj.roster_backup[1]) is Player
+
+    def test_mixed(self):
+        data = {
+            'roster': [
+                {
+                    'player1'
+                },
+                {
+                    'player2'
+                },
+                {
+                    'player3'
+                }
+            ],
+            'roster_backup': {
+                1: 5,
+                2: 3,
+                3: 2
+            }
+        }
+        json_str = json.dumps(data)
+        obj: Team = ListUnion.from_json(json_str)
+
+        assert type(obj.roster[0]) is Player and type(obj.roster_backup[1]) is int
+
+    def test_mixed_inverse(self):
+        data = {
+            'roster': [
+                1,
+                2,
+                3
+            ],
+            'roster_backup': {
+                1: {
+                    'player1'
+                },
+                2: {
+                    'player2'
+                },
+                3: {
+                    'player3'
+                }
+            }
+        }
+        json_str = json.dumps(data)
+        obj: Team = ListUnion.from_json(json_str)
+
+        assert type(obj.roster[0]) is int and type(obj.roster_backup[1]) is Player

--- a/tests/test_collection_of_unions.py
+++ b/tests/test_collection_of_unions.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 from typing import Dict, Union, List
-import json
 
 from dataclasses_json import dataclass_json
 

--- a/tests/test_collection_of_unions.py
+++ b/tests/test_collection_of_unions.py
@@ -1,0 +1,64 @@
+from dataclasses import dataclass
+from typing import Dict, Union, List
+
+from dataclasses_json import dataclass_json
+
+
+@dataclass_json
+@dataclass(frozen=True)
+class TestChild:
+    some_field: int = None
+
+
+@dataclass_json
+@dataclass(frozen=True)
+class TestOtherChild:
+    other_field: int = None
+
+
+@dataclass_json
+@dataclass(frozen=True)
+class NotWorkingDictUnion:
+    d: Dict[str, Union[TestChild, TestOtherChild]]
+
+
+@dataclass_json
+@dataclass(frozen=True)
+class NotWorkingListUnion:
+    l: List[Union[TestChild, TestOtherChild]]
+
+
+class TestCollectionOfUnions:
+    def test_dict(self):
+        data = {
+            "d": {
+                "child" : {
+                    "some_field" : 1
+                },
+                "other_child" : {
+                    "other_field" : 2
+                }
+            }
+        }
+        json_str = NotWorkingDictUnion.to_json(data)
+        obj = NotWorkingDictUnion.from_json(json_str)
+
+        # type is <class 'dict'>, as opposed to TestChild/TestOtherChild
+        assert type(obj.d['child']) in (TestChild, TestOtherChild)
+
+    def test_list(self):
+        data = {
+            "l": [
+                {
+                    "some_field" : 1
+                },
+                {
+                    "other_field" : 1
+                }
+            ]
+        }
+        json_str = NotWorkingListUnion.to_json(data)
+        obj = NotWorkingListUnion.from_json(json_str)
+
+        # type is <class 'dict'>, as opposed to TestChild/TestOtherChild
+        assert type(obj.l[0]) in (TestChild, TestOtherChild)

--- a/tests/test_collection_of_unions.py
+++ b/tests/test_collection_of_unions.py
@@ -38,7 +38,7 @@ class Player:
 @dataclass_json
 @dataclass(frozen=True)
 class Team:
-    roster: list[Union[int, Player]]
+    roster: List[Union[int, Player]]
     roster_backup: dict[int, Union[int, Player]]
 
 

--- a/tests/test_collection_of_unions.py
+++ b/tests/test_collection_of_unions.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from typing import Dict, Union, List
+import json
 
 from dataclasses_json import dataclass_json
 
@@ -40,10 +41,9 @@ class TestCollectionOfUnions:
                 }
             }
         }
-        json_str = NotWorkingDictUnion.schema().dump(data)
+        json_str = json.dumps(data)
         obj = NotWorkingDictUnion.from_json(json_str)
 
-        # type is <class 'dict'>, as opposed to TestChild/TestOtherChild
         assert type(obj.d['child']) in (TestChild, TestOtherChild)
 
     def test_list(self):
@@ -57,8 +57,7 @@ class TestCollectionOfUnions:
                 }
             ]
         }
-        json_str = NotWorkingListUnion.schema().dump(data)
+        json_str = json.dumps(data)
         obj = NotWorkingListUnion.from_json(json_str)
 
-        # type is <class 'dict'>, as opposed to TestChild/TestOtherChild
         assert type(obj.l[0]) in (TestChild, TestOtherChild)

--- a/tests/test_collection_of_unions.py
+++ b/tests/test_collection_of_unions.py
@@ -97,24 +97,24 @@ class TestCollectionOfUnions:
         data = {
             'roster': [
                 {
-                    'player1'
+                    'name': 'player1'
                 },
                 {
-                    'player2'
+                    'name': 'player2'
                 },
                 {
-                    'player3'
+                    'name': 'player3'
                 }
             ],
             'roster_backup': {
                 1: {
-                    'player1'
+                    'name': 'player1'
                 },
                 2: {
-                    'player2'
+                    'name': 'player2'
                 },
                 3: {
-                    'player3'
+                    'name': 'player3'
                 }
             }
         }
@@ -127,13 +127,13 @@ class TestCollectionOfUnions:
         data = {
             'roster': [
                 {
-                    'player1'
+                    'name': 'player1'
                 },
                 {
-                    'player2'
+                    'name': 'player2'
                 },
                 {
-                    'player3'
+                    'name': 'player3'
                 }
             ],
             'roster_backup': {
@@ -156,13 +156,13 @@ class TestCollectionOfUnions:
             ],
             'roster_backup': {
                 1: {
-                    'player1'
+                    'name': 'player1'
                 },
                 2: {
-                    'player2'
+                    'name': 'player2'
                 },
                 3: {
-                    'player3'
+                    'name': 'player3'
                 }
             }
         }

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -39,8 +39,18 @@ class Aux2:
 
 @dataclass_json
 @dataclass
+class Aux3:
+    f2: str
+
+@dataclass_json
+@dataclass
 class C4:
     f1: Union[Aux1, Aux2]
+
+@dataclass_json
+@dataclass
+class C12:
+    f1: Union[Aux2, Aux3]
 
 
 @dataclass_json
@@ -198,3 +208,29 @@ def test_deserialize_with_error(cls, data):
     s = cls.schema()
     with pytest.raises(ValidationError):
         assert s.load(data)
+
+def test_deserialize_without_discriminator():
+    # determine based on type
+    json = '{"f1": {"f1": 1}}'
+    s = C4.schema()
+    obj = s.loads(json)
+    assert obj.f1 is not None
+    assert type(obj.f1) == Aux1
+
+    json = '{"f1": {"f1": "str1"}}'
+    s = C4.schema()
+    obj = s.loads(json)
+    assert obj.f1 is not None
+    assert type(obj.f1) == Aux2
+
+    # determine based on field name
+    json = '{"f1": {"f1": "str1"}}'
+    s = C12.schema()
+    obj = s.loads(json)
+    assert obj.f1 is not None
+    assert type(obj.f1) == Aux2
+    json = '{"f1": {"f2": "str1"}}'
+    s = C12.schema()
+    obj = s.loads(json)
+    assert obj.f1 is not None
+    assert type(obj.f1) == Aux3


### PR DESCRIPTION
This PR builds upon @pawelwilczewski's work to attempt to choose the correct dataclass from the list of union options and decode into the correct one depending on field names, and primitive types.